### PR TITLE
Fix package detection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Change Log
 
 Next Release
 ------------
+* Improved parsing of package information
 
 1.6.0 (2020-10-11)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,6 @@ Example
 Copyright
 =========
 
-* Copyright © 2018-2020, Moritz E. Beber.
+* Copyright © 2018-2021, Moritz E. Beber.
 * Free software distributed under the `Apache Software License 2.0
   <https://www.apache.org/licenses/LICENSE-2.0>`_.

--- a/src/depinfo/info.py
+++ b/src/depinfo/info.py
@@ -17,6 +17,7 @@
 
 
 import platform
+import re
 from typing import Dict, Iterable, Tuple
 
 
@@ -53,7 +54,7 @@ def _get_package_version(requirement: str) -> Tuple[str, str]:
             environment.
 
     """
-    package = requirement.split(";", 1)[0].strip()
+    package = re.split(r"[;<>=\s]", requirement)[0]
     return package, version(package)
 
 

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -22,6 +22,7 @@ from typing import Dict
 import pytest
 
 import depinfo
+from depinfo.info import _get_package_version
 
 
 def test_get_sys_info() -> None:
@@ -56,6 +57,26 @@ def test_print_info(capsys, blob: Dict[str, str], output: str) -> None:
     depinfo.print_info(blob)
     captured = capsys.readouterr()
     assert captured.out == output
+
+
+@pytest.mark.parametrize(
+    "requirement, package",
+    [
+        ("pip", "pip"),
+        ("pip (~=1.4)", "pip"),
+        ("pip (==5.18.3)", "pip"),
+        ("pip (<1.4.6)", "pip"),
+        ("pip (>1.4.6)", "pip"),
+        ("pip>=2.0.5", "pip"),
+        ("pip==1.19.3", "pip"),
+        ('pip>=6.1; extra == "development"', "pip"),
+        ('pip>=6.1 ; extra == "development"', "pip"),
+    ],
+)
+def test_get_package_version(requirement, package):
+    """Expect package to be parsed from requirement."""
+    p, _ = _get_package_version(requirement)
+    assert p == package
 
 
 def test_print_dependencies(capsys) -> None:


### PR DESCRIPTION
* [x] fix #5 
* [x] description of feature/fix
* [x] tests added/passed
* [x] add an entry to the [next release](../CHANGELOG.rst)

Handles parsing of package information from requirement in a more robust manner by using regular expressions instead of split. Example test cases which failed for me have been added and are passing now.